### PR TITLE
Install node pulumi-svmkit directly rather than linking

### DIFF
--- a/bin/with-local-pulumi-svmkit
+++ b/bin/with-local-pulumi-svmkit
@@ -25,7 +25,7 @@ rm -rf node_modules venv
 pulumi install
 
 if [[ -d node_modules ]] ; then
-    yarn link "@svmkit/pulumi-svmkit"
+    yarn add "$PULUMI_SVMKIT_DIR"/sdk/nodejs/bin
 elif [[ -d venv ]] ; then
     ./venv/bin/pip install "$PULUMI_SVMKIT_DIR"/sdk/python/bin/dist/pulumi_svmkit-*.tar.gz
 else


### PR DESCRIPTION
The current method causes hard-to-debug side effects because the yarn link is global.  We did it originally because that's how the upstream pulumi dev environment worked.  This changes things to install the local version, just like we do for Python.